### PR TITLE
Fix unicode secret keys

### DIFF
--- a/httpie_api_auth.py
+++ b/httpie_api_auth.py
@@ -17,7 +17,7 @@ __licence__ = 'MIT'
 class ApiAuth:
     def __init__(self, access_id, secret_key):
         self.access_id = access_id
-        self.secret_key = secret_key
+        self.secret_key = secret_key.encode('ascii')
 
     def __call__(self, r):
         content_type = r.headers.get('content-type')


### PR DESCRIPTION
`hmac` accepts unicode in python 2.7 by "accident", but the `translate` calls deep
inside of `hmac` cause it to then generate invalid strings and fail. This ensures
that all secret keys are converted to ascii before calling `hmac.new`. In python 3
`encode()` returns a `bytes` so it shouldn't break compatibility
