### PR TITLE
Change signature of get_auth

### DIFF
--- a/httpie_api_auth.py
+++ b/httpie_api_auth.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     import urllib.parse
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 __author__ = 'Kyle Hargraves'
 __licence__ = 'MIT'
 
@@ -54,5 +54,5 @@ class ApiAuthPlugin(AuthPlugin):
     auth_type = 'api-auth'
     description = 'Sign requests using the ApiAuth authentication method'
 
-    def get_auth(self, access_id, secret_key):
+    def get_auth(self, access_id=None, secret_key=None):
         return ApiAuth(access_id, secret_key)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name='httpie-api-auth',
     description='ApiAuth plugin for HTTPie.',
     long_description=open('README.rst').read().strip(),
-    version='0.3.0',
+    version='0.3.1',
     author='Kyle Hargraves',
     author_email='pd@krh.me',
     license='MIT',


### PR DESCRIPTION
For some reason this now requires the function signature to recognize
the possiblity that these keys are not sent.

Based on: https://github.com/guardian/httpie-hmac-auth/pull/4