### PR TITLE
1.0.2 support. Python 3 endode / decode problems fixed

### DIFF
--- a/httpie_api_auth.py
+++ b/httpie_api_auth.py
@@ -4,20 +4,16 @@ ApiAuth auth plugin for HTTPie.
 """
 from httpie.plugins import AuthPlugin
 import hmac, base64, hashlib, datetime
+import urllib.parse
 
-try:
-    import urlparse
-except ImportError:
-    import urllib.parse
-
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 __author__ = 'Kyle Hargraves'
 __licence__ = 'MIT'
 
 class ApiAuth:
-    def __init__(self, access_id, secret_key):
-        self.access_id = access_id
-        self.secret_key = secret_key.encode('ascii')
+    def __init__(self, username=None, password=None):
+        self.username = username
+        self.password = password.encode('ascii')
 
     def __call__(self, r):
         method = r.method.upper()
@@ -36,16 +32,17 @@ class ApiAuth:
             httpdate = now.strftime('%a, %d %b %Y %H:%M:%S GMT')
             r.headers['Date'] = httpdate
 
-        url  = urlparse.urlparse(r.url)
+        url  = urllib.parse.urlparse(r.url)
         path = url.path
         if url.query:
           path = path + '?' + url.query
 
-        string_to_sign = '%s,%s,%s,%s,%s' % (method, content_type, content_md5, path, httpdate)
-        digest = hmac.new(self.secret_key, string_to_sign, hashlib.sha1).digest()
+        string_to_sign = '%s,%s,%s,%s,%s' % (method, content_type.decode(), content_md5, path, httpdate)
+
+        digest = hmac.new(self.password, string_to_sign.encode(), hashlib.sha1).digest()
         signature = base64.encodestring(digest).rstrip()
 
-        r.headers['Authorization'] = 'APIAuth %s:%s' % (self.access_id, signature)
+        r.headers['Authorization'] = 'APIAuth %s:%s' % (self.username, signature.decode())
         return r
 
 class ApiAuthPlugin(AuthPlugin):
@@ -54,5 +51,5 @@ class ApiAuthPlugin(AuthPlugin):
     auth_type = 'api-auth'
     description = 'Sign requests using the ApiAuth authentication method'
 
-    def get_auth(self, access_id, secret_key):
-        return ApiAuth(access_id, secret_key)
+    def get_auth(self, username, password):
+        return ApiAuth(username, password)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name='httpie-api-auth',
     description='ApiAuth plugin for HTTPie.',
     long_description=open('README.rst').read().strip(),
-    version='0.3.0',
+    version='0.3.1',
     author='Kyle Hargraves',
     author_email='pd@krh.me',
     license='MIT',


### PR DESCRIPTION
This lets people use Python3, and newer versions of httpie. maybe.